### PR TITLE
add noPlayersToggle option

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -49,6 +49,7 @@ public class Config {
     private static int fillMemoryTolerance = 500;
     private static boolean preventBlockPlace = false;
     private static boolean preventMobSpawn = false;
+    private static boolean noPlayersToggle = false;
 
     // for monitoring plugin efficiency
     //	public static long timeUsed = 0;
@@ -289,6 +290,8 @@ public class Config {
     public static double KnockBack() {
         return knockBack;
     }
+
+    public static boolean NoPlayersToggle() { return noPlayersToggle; }
 
     public static void setTimerTicks(int ticks) {
         timerTicks = ticks;
@@ -531,6 +534,7 @@ public class Config {
         fillMemoryTolerance = cfg.getInt("fill-memory-tolerance", 500);
         preventBlockPlace = cfg.getBoolean("prevent-block-place");
         preventMobSpawn = cfg.getBoolean("prevent-mob-spawn");
+        noPlayersToggle = cfg.getBoolean("no-players-toggle");
 
         StartBorderTimer();
 
@@ -634,6 +638,7 @@ public class Config {
         cfg.set("fill-memory-tolerance", fillMemoryTolerance);
         cfg.set("prevent-block-place", preventBlockPlace);
         cfg.set("prevent-mob-spawn", preventMobSpawn);
+        cfg.set("no-players-toggle", noPlayersToggle);
 
         cfg.set("worlds", null);
         for (Entry<String, BorderData> stringBorderDataEntry : borders.entrySet()) {

--- a/src/main/java/com/wimbli/WorldBorder/WBListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBListener.java
@@ -1,11 +1,15 @@
 package com.wimbli.WorldBorder;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.Server;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
@@ -83,4 +87,23 @@ public class WBListener implements Listener {
         chunk.setForceLoaded(false);
     }
 
+    // If player joins and noPlayersToggle is on automatically pause any existing fill task
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent e) {
+        if (!Config.NoPlayersToggle() || Config.fillTask == null || Config.fillTask.isPaused())
+            return;
+
+        Config.fillTask.pause(true);
+        Config.log("Detected player online. World map generation task automatically paused.");
+    }
+
+    // If no players online and noPlayersToggle is on automatically unpause any existing fill task
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        if (!Config.NoPlayersToggle() || Config.fillTask == null || Bukkit.getOnlinePlayers().size() > 1 || !Config.fillTask.isPaused())
+            return;
+
+        Config.fillTask.pause(false);
+        Config.log("No players online. World map generation task automatically unpaused.");
+    }
 }


### PR DESCRIPTION
this adds an option to automatically pause/unpause the worldBorder fill based on players connecting or disconnecting from the server

just thought it would be useful as currently I play on a server with some friends and we'd like the server to generate chunks when we aren't online so it is faster when we are.

option togglable in the config.yml file under `no-players-toggle`