### PR TITLE
Customizable dynmap label

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wimbli.WorldBorder</groupId>
     <artifactId>WorldBorder</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <name>WorldBorder</name>
     <url>https://github.com/PryPurity/WorldBorder</url>
     <issueManagement>

--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -39,6 +39,7 @@ public class Config {
     private static boolean whooshEffect = false;
     private static boolean portalRedirection = true;
     private static boolean dynmapEnable = false;
+    private static String dynmapLayerLabel;
     private static String dynmapMessage;
     private static int dynmapPriority = 0;
     private static boolean dynmapHideByDefault = false;
@@ -341,6 +342,17 @@ public class Config {
         return dynmapEnable;
     }
 
+    public static void setDynmapLayerLabel(String label) {
+        dynmapLayerLabel = label;
+        log("DynMap layer label is now set to: " + label);
+        save(true);
+        DynMapFeatures.showAllBorders();
+    }
+
+    public static String DynmapLayerLabel() {
+        return dynmapLayerLabel;
+    }
+
     public static void setDynmapMessage(String msg) {
         dynmapMessage = msg;
         log("DynMap border label is now set to: " + msg);
@@ -520,6 +532,7 @@ public class Config {
         timerTicks = cfg.getInt("timer-delay-ticks", 5);
         remountDelayTicks = cfg.getInt("remount-delay-ticks", 0);
         dynmapEnable = cfg.getBoolean("dynmap-border-enabled", true);
+        dynmapLayerLabel = cfg.getString("dynmap-border-layer-label", "WorldBorder");
         dynmapMessage = cfg.getString("dynmap-border-message", "The border of the world.");
         dynmapHideByDefault = cfg.getBoolean("dynmap-border-hideByDefault", false);
         dynmapPriority = cfg.getInt("dynmap-border-priority", 0);
@@ -624,6 +637,7 @@ public class Config {
         cfg.set("timer-delay-ticks", timerTicks);
         cfg.set("remount-delay-ticks", remountDelayTicks);
         cfg.set("dynmap-border-enabled", dynmapEnable);
+        cfg.set("dynmap-border-layer-label", dynmapLayerLabel);
         cfg.set("dynmap-border-message", dynmapMessage);
         cfg.set("dynmap-border-hideByDefault", dynmapHideByDefault);
         cfg.set("dynmap-border-priority", dynmapPriority);

--- a/src/main/java/com/wimbli/WorldBorder/DynMapFeatures.java
+++ b/src/main/java/com/wimbli/WorldBorder/DynMapFeatures.java
@@ -127,9 +127,9 @@ public class DynMapFeatures {
         // make sure the marker set is initialized
         markSet = markApi.getMarkerSet("worldborder.markerset");
         if (markSet == null)
-            markSet = markApi.createMarkerSet("worldborder.markerset", "WorldBorder", null, false);
+            markSet = markApi.createMarkerSet("worldborder.markerset", Config.DynmapLayerLabel(), null, false);
         else
-            markSet.setMarkerSetLabel("WorldBorder");
+            markSet.setMarkerSetLabel(Config.DynmapLayerLabel());
         markSet.setLayerPriority(Config.DynmapPriority());
         markSet.setHideByDefault(Config.DynmapHideByDefault());
         Map<String, BorderData> borders = Config.getBorders();

--- a/src/main/java/com/wimbli/WorldBorder/WBCommand.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBCommand.java
@@ -43,6 +43,7 @@ public class WBCommand implements CommandExecutor {
         addCmd(new CmdPreventSpawn());    // 1
         addCmd(new CmdDelay());            // 1
         addCmd(new CmdDynmap());        // 1
+        addCmd(new CmdDynmaplabel());        // 1
         addCmd(new CmdDynmapmsg());        // 1
         addCmd(new CmdRemount());        // 1
         addCmd(new CmdFillautosave());    // 1

--- a/src/main/java/com/wimbli/WorldBorder/cmd/CmdDynmaplabel.java
+++ b/src/main/java/com/wimbli/WorldBorder/cmd/CmdDynmaplabel.java
@@ -1,0 +1,42 @@
+package com.wimbli.WorldBorder.cmd;
+
+import com.wimbli.WorldBorder.Config;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+
+public class CmdDynmaplabel extends WBCmd {
+    public CmdDynmaplabel() {
+        name = permission = "dynmaplabel";
+        minParams = 1;
+
+        addCmdExample(nameEmphasized() + "<text> - DynMap border layer labels will show this.");
+        helpText = "Default value: \"WorldBorder.\". If you are running the DynMap plugin and the " +
+                commandEmphasized("dynmap") + C_DESC + "command setting is enabled, the border layer shown in DynMap will " +
+                "be labelled with this text.";
+    }
+
+    @Override
+    public void cmdStatus(CommandSender sender) {
+        sender.sendMessage(C_HEAD + "DynMap border layer label is set to: " + C_ERR + Config.DynmapLayerLabel());
+    }
+
+    @Override
+    public void execute(CommandSender sender, Player player, List<String> params, String worldName) {
+        StringBuilder message = new StringBuilder();
+        boolean first = true;
+        for (String param : params) {
+            if (!first)
+                message.append(" ");
+            message.append(param);
+            first = false;
+        }
+
+        Config.setDynmapLayerLabel(message.toString());
+
+        if (player != null)
+            cmdStatus(sender);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: WorldBorder
 authors: [Brettflan, PryPurity]
 description: Efficient, feature-rich plugin for limiting the size of your worlds.
-version: 2.1.0
+version: 2.1.1
 api-version: 1.16
 main: com.wimbli.WorldBorder.WorldBorder
 softdepend:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -39,6 +39,7 @@ commands:
       /<command> wshape [world] <round|square|default> - same as above values.
       /<command> delay <amount> - time between border checks.
       /<command> dynmap <on/off> - turn DynMap border display on or off.
+      /<command> dynmaplabel <text> - DynMap border layer label will show this.
       /<command> dynmapmsg <text> - DynMap border labels will show this.
       /<command> remount <amount> - delay before remounting after knockback.
       /<command> fillautosave <seconds> - world save interval for Fill process.


### PR DESCRIPTION
Currently the dynmap layer label is hardcoded to "WorldBorder". This PR adds an option and an ingame command to change this layer label, so people can adjust it to their liking / language of their server. I've tried to match the current code style.