### PR TITLE
Allow No Border Message

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/BorderCheckTask.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderCheckTask.java
@@ -124,8 +124,11 @@ public class BorderCheckTask implements Runnable {
         if (Config.Debug())
             Config.logWarn("New position in world \"" + newLoc.getWorld().getName() + "\" at X: " + Config.coord.format(newLoc.getX()) + " Y: " + Config.coord.format(newLoc.getY()) + " Z: " + Config.coord.format(newLoc.getZ()));
 
-        if (notify)
-            player.sendMessage(Config.Message());
+        if (notify) {
+        	if(!Config.Message().isBlank()) {
+        		player.sendMessage(Config.Message());
+        	}
+        }          
 
         return newLoc;
     }

--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -556,7 +556,7 @@ public class Config {
         borders.clear();
 
         // if empty border message, assume no config
-        if (msg == null || msg.isEmpty()) {    // store defaults
+        if (msg == null) {    // store defaults
             logConfig("Configuration not present, creating new file.");
             msg = "&cYou have reached the edge of this world.";
             updateMessage(msg);


### PR DESCRIPTION
Small Change to allow there to actually be no border message. Useful if you're using wrap or something and want the world to seem more seamless when wrapping.