### PR TITLE
Use PaperLib's isChunkGenerated to prevent loading chunks already generated

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/WorldFileData.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldFileData.java
@@ -1,5 +1,6 @@
 package com.wimbli.WorldBorder;
 
+import io.papermc.lib.PaperLib;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
@@ -103,7 +104,10 @@ public class WorldFileData {
         CoordXZ region = new CoordXZ(CoordXZ.chunkToRegion(x), CoordXZ.chunkToRegion(z));
         List<Boolean> regionChunks = this.getRegionData(region);
 //		Bukkit.getLogger().info("x: "+x+"  z: "+z+"  offset: "+coordToRegionOffset(x, z));
-        return regionChunks.get(coordToRegionOffset(x, z));
+        if (regionChunks.get(coordToRegionOffset(x, z))) {
+            return true;
+        }
+        return PaperLib.isChunkGenerated(world, x, z);
     }
 
     // Find out if the chunk at the given coordinates has been fully generated.


### PR DESCRIPTION
This method supports both Paper and Spigot 1.13+, and the project already uses PaperLib, so this isn't a large change.


### Testing:
**Percentage: 5%**
Current spigot release: **11:42** (mins:secs)
PR: **2:07**
553% speed increase :O
Memory is also decreased from nearly the JVM limit to a low amount (in my case 6GB -> 2GB with 8GB limit)
**This is only while testing already-generated chunks, read the information below for more details**

**However,** I've only tested this against existing chunks, and PaperLib's method is actually about 2-4x slower than the one used currently (since the current one is just a cache afaik), so this may not be the best for new chunks. (PaperLib: `1800ns`, Current: ~`500ns`, varies quite a bit, but mostly 2-4x slower)

But seeing the results above, I still think that this should be implemented, although probably with a config option (since this PR would just decrease the performance if the server is up without any restarts - but if the server restarts often or isn't being hosted 24/7, then this would bring a large performance increase along with a lot less memory usage)